### PR TITLE
Change settings header: "Remap keys" in KBM

### DIFF
--- a/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
+++ b/src/core/Microsoft.PowerToys.Settings.UI/Strings/en-us/Resources.resw
@@ -182,7 +182,7 @@
     <comment>Keyboard Manager remap keyboard button content</comment>
   </data>
   <data name="KeyboardManager_RemapKeyboardHeader.Text" xml:space="preserve">
-    <value>Remap keyboard</value>
+    <value>Remap keys</value>
     <comment>Keyboard Manager remap keyboard header</comment>
   </data>
   <data name="KeyboardManager_RemapShortcutsButton.Content" xml:space="preserve">


### PR DESCRIPTION
We write "Remap Keyboard" but it must be "Remap keys" because we not remapping the whole keyboard. We only remap single keys.

## Summary of the Pull Request

<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist
* [X] Applies to #3527
* [X] CLA signed. If not, go over [here](https://cla.opensource.microsoft.com/microsoft/PowerToys) and sign the CLA
* [ ] Tests added/passed
* [ ] Requires documentation to be updated
* [X] I've discussed this with core contributors already. If not checked, I'm ready to accept this work might be rejected in favor of a different grand plan. Issue number where discussion took place: #3527

## Detailed Description of the Pull Request / Additional comments
In the title for the settings section Remap keys in the KBM settings we wrote "Remap keyboard". But this is false because we not remapping the whole keyboard. We only remapping single keys. So it must be named "Remap keys". This is fixed with this PR.

## Validation Steps Performed
No validation done.